### PR TITLE
helper function to retrieve response as string

### DIFF
--- a/Model/Api/Response.php
+++ b/Model/Api/Response.php
@@ -45,6 +45,19 @@ class Response {
         return $this->response;
     }
 
+    /**
+     * @return string
+     */
+    public function getResponseMessage()
+    {
+        $responseString = $this->getResponse();
+        if (is_array($responseString)) {
+            $responseString = json_encode($responseString);
+        }
+
+        return $responseString;
+    }
+
     public function getModelData($key){
         if(isset($this->response[$key])){
             return $this->response[$key];

--- a/Service/XeroService.php
+++ b/Service/XeroService.php
@@ -78,7 +78,7 @@ class XeroService {
                     }
                 }
             } else {
-                throw new \RuntimeException($response->getResponse(), $response->getCode());
+                throw new \RuntimeException($response->getResponseMessage(), $response->getCode());
             }
         }
         return null;
@@ -118,11 +118,7 @@ class XeroService {
                 }
                 return $paymentArr;
             } else {
-                $responseString = $response->getResponse();
-                if(is_array($responseString)){
-                    $responseString = json_encode($responseString);
-                }
-                throw new \RuntimeException($responseString, $response->getCode());
+                throw new \RuntimeException($response->getResponseMessage(), $response->getCode());
             }
         }
         return null;


### PR DESCRIPTION
`getResponseMessage()` was returning mixed values (`strings|array`) which would cause issues when throwing `new RuntimeException`.

Following request uses a helper function to convert the array to a json encoded string before passing it to `RuntimeException`.
